### PR TITLE
config/sap-hana: Only deploy AAP software if offline_token is defined…

### DIFF
--- a/ansible/configs/sap-hana/software.yml
+++ b/ansible/configs/sap-hana/software.yml
@@ -127,9 +127,11 @@
         state: present
         key: "{{ ansible_tower_epel_gpg_download_url }}"
 
+    ## Don't include the role if offline_token is not defined
     - name: Install AAP 2
       include_role:
         name: install-aap2
+      when: offline_token is defined
 
 - name: Software flight-check
   hosts: localhost


### PR DESCRIPTION
Comment out AAP2 install as requested